### PR TITLE
fix: pin zotero-plugin-toolkit to 5.1.0-beta.4 for stable CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "update-deps": "npm update --save"
   },
   "dependencies": {
-    "zotero-plugin-toolkit": "^5.1.0-beta.4"
+    "zotero-plugin-toolkit": "5.1.0-beta.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",


### PR DESCRIPTION
- pin zotero-plugin-toolkit to 5.1.0-beta.4
- prevent CI from resolving 5.1.2, which caused the Zotero context menu item and toolbar button to disappear
- keep the current CI flow unchanged while restoring the known-good XPI output