### PR TITLE
feat: add customizable plugin shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@
 
 ## 快捷键
 
-- `Shift+A` 翻译选中的文献
-- `Shift+T` 打开任务管理窗口
+- `Ctrl+Shift+B`（macOS 为 `Cmd+Shift+B`）翻译选中的文献
+- `Ctrl+Shift+H`（macOS 为 `Cmd+Shift+H`）打开任务管理窗口
+- 可在插件设置页修改、清空或恢复默认快捷键；清空某一项只会停用对应动作。
 
 ## FAQ
 

--- a/addon/content/preferences.xhtml
+++ b/addon/content/preferences.xhtml
@@ -156,10 +156,49 @@
       />
     </vbox>
     <vbox>
-      <p data-l10n-id="pref-enable-shortcuts-description-1" />
+      <p data-l10n-id="pref-shortcuts-description" />
+    </vbox>
+    <vbox style="margin-top: 8px">
+      <html:label
+        for="zotero-prefpane-__addonRef__-shortcut-translate"
+        data-l10n-id="pref-shortcut-translate"
+      ></html:label>
+      <hbox align="center">
+        <html:input
+          id="zotero-prefpane-__addonRef__-shortcut-translate"
+          type="text"
+          preference="shortcutTranslate"
+          style="width: 160px; margin-right: 6px"
+        ></html:input>
+        <button
+          id="zotero-prefpane-__addonRef__-shortcut-translate-reset"
+          data-l10n-id="pref-shortcut-reset"
+        ></button>
+      </hbox>
+    </vbox>
+    <vbox style="margin-top: 8px">
+      <html:label
+        for="zotero-prefpane-__addonRef__-shortcut-task-manager"
+        data-l10n-id="pref-shortcut-task-manager"
+      ></html:label>
+      <hbox align="center">
+        <html:input
+          id="zotero-prefpane-__addonRef__-shortcut-task-manager"
+          type="text"
+          preference="shortcutTaskManager"
+          style="width: 160px; margin-right: 6px"
+        ></html:input>
+        <button
+          id="zotero-prefpane-__addonRef__-shortcut-task-manager-reset"
+          data-l10n-id="pref-shortcut-reset"
+        ></button>
+      </hbox>
     </vbox>
     <vbox>
-      <p data-l10n-id="pref-enable-shortcuts-description-2" />
+      <p
+        id="zotero-prefpane-__addonRef__-shortcut-feedback"
+        data-l10n-id="pref-shortcut-conflict-guidance"
+      />
     </vbox>
   </groupbox>
 

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -1,10 +1,13 @@
 startup-begin = Addon is loading
 startup-finish = Addon is ready
-menuitem-translate = Translate with ImmersiveTranslate(Shift+A)
-menuView-tasks = View Immersive translate tasks(Shift+T)
+menuitem-translate = Translate with ImmersiveTranslate(Ctrl/Cmd+Shift+B)
+menuView-tasks = View Immersive translate tasks(Ctrl/Cmd+Shift+H)
 pref-test-success = Test successfully
 pref-test-failed = Test failed
 pref-test-failed-description = Please check your authkey
+pref-shortcut-duplicate-error = This shortcut is already used by another plugin action. Plugin shortcuts must be unique.
+pref-shortcut-native-conflict-error = Shift+letter is reserved by Zotero item-list navigation and cannot be used as a plugin shortcut.
+pref-shortcut-conflict-guidance = Custom shortcuts may conflict with Zotero or system shortcuts. Conflicting values are allowed, but Zotero or the system may handle them first.
 
 prefs-title = Immersive Translate
 item-filed-status = Translation Status
@@ -41,6 +44,10 @@ layoutModel-version-3 = Version 3
 
 confirm-title = Translate Confirm
 confirm-options = Options
+confirm-article-single = Selected article
+confirm-article-multiple = { $count } selected items. First item shown below.
+confirm-article-unknown = Untitled article
+confirm-article-metadata-unknown = Author/year unavailable
 confirm-enable-compatibility = Enable compatibility mode
 confirm-enable-compatibility-description = Enabling this will improve PDF compatibility, but will increase the output file size.
 confirm-enable-ocr-workaround = Enable OCR temporary solution

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -27,8 +27,13 @@ pref-imt-site = Get your authorization key from your personal page on Immersive 
 pref-shortcuts-settings = Shortcuts
 pref-enable-shortcuts =
     .label = Enable shortcuts
-pref-enable-shortcuts-description-1 = Translate selected items
-pref-enable-shortcuts-description-2 = Open task manager
+pref-shortcuts-description = Defaults use Ctrl on Windows/Linux and Cmd on macOS. Clear a field to disable only that action.
+pref-shortcut-translate = Translate selected items shortcut
+pref-shortcut-task-manager = Open task manager shortcut
+pref-shortcut-reset =
+    .label = Reset
+pref-shortcut-duplicate-error = This shortcut is already used by another plugin action. Plugin shortcuts must be unique.
+pref-shortcut-conflict-guidance = Custom shortcuts may conflict with Zotero or system shortcuts. Conflicting values are allowed, except Shift+letter, which is reserved for Zotero item-list navigation.
 
 pref-translate-settings = Translation
 

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -1,10 +1,13 @@
 startup-begin = 插件加载中
 startup-finish = 插件已就绪
-menuitem-translate = 使用沉浸式翻译(Shift+A)
-menuView-tasks = 查看沉浸式翻译任务(Shift+T)
+menuitem-translate = 使用沉浸式翻译(Ctrl/Cmd+Shift+B)
+menuView-tasks = 查看沉浸式翻译任务(Ctrl/Cmd+Shift+H)
 pref-test-success = 测试成功
 pref-test-failed = 测试失败
 pref-test-failed-description = 请检查授权码是否正确
+pref-shortcut-duplicate-error = 该快捷键已被另一个插件动作使用。插件快捷键不能重复。
+pref-shortcut-native-conflict-error = Shift+字母 是 Zotero 条目列表原生跳转功能，不能作为插件快捷键。
+pref-shortcut-conflict-guidance = 自定义快捷键可能与 Zotero 或系统快捷键冲突。插件不会因此阻止保存，但 Zotero 或系统可能会优先处理。
 
 prefs-title = 沉浸式翻译
 item-filed-status = 翻译状态
@@ -41,6 +44,10 @@ layoutModel-version-3 = 版本 3
 
 confirm-title = 翻译确认
 confirm-options = 选项
+confirm-article-single = 当前选择的文章
+confirm-article-multiple = 已选择 { $count } 个条目。下方显示第一项。
+confirm-article-unknown = 未命名文章
+confirm-article-metadata-unknown = 作者/年份不可用
 confirm-enable-compatibility = 是否启用兼容模式
 confirm-enable-compatibility-description = 启用后将会改善 PDF 兼容性，但是会增大输出文件大小
 confirm-enable-ocr-workaround = 是否启用 OCR 临时解决方案

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -26,8 +26,13 @@ pref-enable-autoTranslate-description = 启用后将会自动翻译新添加的 
 pref-shortcuts-settings = 快捷键
 pref-enable-shortcuts =
     .label = 启用快捷键
-pref-enable-shortcuts-description-1 = Shift + A 翻译所选条目
-pref-enable-shortcuts-description-2 = Shift + T 打开翻译任务管理器
+pref-shortcuts-description = 默认快捷键在 Windows/Linux 使用 Ctrl，在 macOS 使用 Cmd。清空某一项只会停用该动作。
+pref-shortcut-translate = 翻译所选条目快捷键
+pref-shortcut-task-manager = 打开翻译任务管理器快捷键
+pref-shortcut-reset =
+    .label = 恢复默认
+pref-shortcut-duplicate-error = 该快捷键已被另一个插件动作使用。插件快捷键不能重复。
+pref-shortcut-conflict-guidance = 自定义快捷键可能与 Zotero 或系统快捷键冲突。除 Zotero 条目列表原生使用的 Shift+字母 外，插件不会因此阻止保存。
 
 pref-imt-site = 在沉浸式翻译官网个人主页获取授权码
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -14,5 +14,7 @@ pref("dualMode", "lort");
 pref("customSystemPrompt", "");
 pref("fakeUserId", "");
 pref("enableShortcuts", true);
+pref("shortcutTranslate", "Mod+Shift+B");
+pref("shortcutTaskManager", "Mod+Shift+H");
 pref("layoutModel", "version_3");
 pref("skipNetworkWarning", false);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "update-deps": "npm update --save"
   },
   "dependencies": {
-    "zotero-plugin-toolkit": "5.1.0-beta.4"
+    "zotero-plugin-toolkit": "5.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       zotero-plugin-toolkit:
-        specifier: ^5.1.0-beta.4
-        version: 5.1.0-beta.4
+        specifier: 5.1.2
+        version: 5.1.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.23.0
@@ -288,30 +288,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.70':
     resolution: {integrity: sha512-wBTOllEYNfJCHOdZj9v8gLzZ4oY3oyPX8MSRvaxPm/s7RfEXxCyZ8OhJ5xAyicsDdbE5YBZqdmaaeP5+xKxvtg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.70':
     resolution: {integrity: sha512-GVUUPC8TuuFqHip0rxHkUqArQnlzmlXmTEBuXAWdgCv85zTCFH8nOHk/YCF5yo0Z2eOm8nOi90aWs0leJ4OE5Q==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.70':
     resolution: {integrity: sha512-/kvUa2lZRwGNyfznSn5t1ShWJnr/m5acSlhTV3eXECafObjl0VBuA1HJw0QrilLpb4Fe0VLywkpD1NsMoVDROQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.70':
     resolution: {integrity: sha512-aqlv8MLpycoMKRmds7JWCfVwNf1fiZxaU7JwJs9/ExjTD8lX2KjsO7CTeAj5Cl4aEuzxUWbJPUUE2Qu9cZ1vfg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-x64-msvc@0.1.70':
     resolution: {integrity: sha512-Q9QU3WIpwBTVHk4cPfBjGHGU4U0llQYRXgJtFtYqqGNEOKVN4OT6PQ+ve63xwIPODMpZ0HHyj/KLGc9CWc3EtQ==}
@@ -465,24 +470,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.29':
     resolution: {integrity: sha512-PwjB10BC0N+Ce7RU/L23eYch6lXFHz7r3NFavIcwDNa/AAqywfxyxh13OeRy+P0cg7NDpWEETWspXeI4Ek8otw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.29':
     resolution: {integrity: sha512-i62vBVoPaVe9A3mc6gJG07n0/e7FVeAvdD9uzZTtGLiuIfVfIBta8EMquzvf+POLycSk79Z6lRhGPZPJPYiQaA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.29':
     resolution: {integrity: sha512-YER0XU1xqFdK0hKkfSVX1YIyCvMDI7K07GIpefPvcfyNGs38AXKhb2byySDjbVxkdl4dycaxxhRyhQ2gKSlsFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.29':
     resolution: {integrity: sha512-po+WHw+k9g6FAg5IJ+sMwtA/fIUL3zPQ4m/uJgONBATCVnDDkyW6dBA49uHNVtSEvjvhuD8DVWdFP847YTcITw==}
@@ -1278,8 +1287,8 @@ packages:
       conventional-changelog:
         optional: true
 
-  zotero-plugin-toolkit@5.1.0-beta.4:
-    resolution: {integrity: sha512-ZlNW2fTA7Pavt7acFywBAoDSBJh3X9A04cFnozs8GFrS4azrdmSDtJny19V8XQIa1HP9vQ9vd94Ueau4EaWz6g==}
+  zotero-plugin-toolkit@5.1.2:
+    resolution: {integrity: sha512-mOxWGWCrwnkNoIAiXQv03La7pfiRyBeLmwbiQQDtm/6PvGAuRYZWTKahPPS+ORKblNs84lpMQ6CdPgwJm0ATZw==}
     engines: {node: '>=18'}
 
   zotero-types@4.1.0-beta.1:
@@ -2492,7 +2501,7 @@ snapshots:
       - '@swc/helpers'
       - magicast
 
-  zotero-plugin-toolkit@5.1.0-beta.4: {}
+  zotero-plugin-toolkit@5.1.2: {}
 
   zotero-types@4.1.0-beta.1:
     dependencies:

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -10,6 +10,7 @@ import { registerToolbar } from "./modules/toolbar";
 import { registerNotifier } from "./modules/notify";
 import {
   addTasksToQueue,
+  addTasksToQueueByIds,
   startQueueProcessing,
   shouldSkipAttachment,
 } from "./modules/translate/task";
@@ -170,7 +171,7 @@ async function onNotify(
       }
     }
     if (newIds.length > 0) {
-      addTasksToQueue(newIds);
+      addTasksToQueueByIds(newIds);
     }
   }
 }
@@ -191,13 +192,13 @@ async function onPrefsEvent(type: string, data: { [key: string]: any }) {
   }
 }
 
-function onShortcuts(type: string, ids?: number[]) {
+function onShortcuts(type: string) {
   if (!getPref("enableShortcuts")) {
     return;
   }
   switch (type) {
     case "translate":
-      addTasksToQueue(ids);
+      addTasksToQueue();
       break;
     case "showTaskManager":
       showTaskManager();

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -21,6 +21,7 @@ import {
 import { showTaskManager } from "./modules/translate/task-manager";
 import { initTasks } from "./modules/translate/store";
 import { getPref } from "./utils/prefs";
+import { removeKnownMenuElements } from "./utils/menu";
 
 async function onStartup() {
   await Promise.all([
@@ -82,9 +83,9 @@ async function onMainWindowLoad(win: _ZoteroTypes.MainWindow): Promise<void> {
     text: `[30%] ${getString("startup-begin")}`,
   });
 
-  registerMenu();
+  registerMenu(win.document);
 
-  registerWindowMenu();
+  registerWindowMenu(win.document);
 
   registerToolbar();
 
@@ -98,13 +99,16 @@ async function onMainWindowLoad(win: _ZoteroTypes.MainWindow): Promise<void> {
 }
 
 async function onMainWindowUnload(win: Window): Promise<void> {
+  removeKnownMenuElements(win.document);
   ztoolkit.unregisterAll();
-  ztoolkit.Menu.unregisterAll();
 }
 
 function onShutdown(): void {
   // 关闭前保存翻译数据
   saveTranslationData();
+  Zotero.getMainWindows?.().forEach((win) => {
+    removeKnownMenuElements(win.document);
+  });
   ztoolkit.unregisterAll();
   // Remove addon object
   addon.data.alive = false;
@@ -187,13 +191,13 @@ async function onPrefsEvent(type: string, data: { [key: string]: any }) {
   }
 }
 
-function onShortcuts(type: string) {
+function onShortcuts(type: string, ids?: number[]) {
   if (!getPref("enableShortcuts")) {
     return;
   }
   switch (type) {
     case "translate":
-      addTasksToQueue();
+      addTasksToQueue(ids);
       break;
     case "showTaskManager":
       showTaskManager();

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -1,30 +1,60 @@
+import { UITool } from "zotero-plugin-toolkit";
 import { getString } from "../utils/locale";
+import { MENU_IDS, removeMenuElement } from "../utils/menu";
 
-export function registerMenu() {
-  ztoolkit.Menu.unregister("zotero-itemmenu-babeldoc-translate");
+export function registerMenu(doc: Document) {
+  removeMenuElement(doc, MENU_IDS.itemTranslate);
+
+  const itemMenu = doc.getElementById("zotero-itemmenu");
+  if (!itemMenu) {
+    return;
+  }
+
+  const ui = new UITool();
   const menuIcon = `chrome://${addon.data.config.addonRef}/content/icons/favicon@0.5x.png`;
   // item menuitem with icon
-  ztoolkit.Menu.register("item", {
-    tag: "menuitem",
-    id: "zotero-itemmenu-babeldoc-translate",
-    label: getString("menuitem-translate"),
-    commandListener: () => addon.hooks.onTranslate(),
-    icon: menuIcon,
+  const menuItem = ui.createElement(doc, "menuitem", {
+    id: MENU_IDS.itemTranslate,
+    attributes: {
+      label: getString("menuitem-translate"),
+      image: menuIcon,
+      class: "menuitem-iconic",
+    },
+    listeners: [
+      {
+        type: "command",
+        listener: () => addon.hooks.onTranslate(),
+      },
+    ],
   });
+  itemMenu.append(menuItem);
 }
 
-export function registerWindowMenu() {
-  ztoolkit.Menu.unregister("zotero-menuview-babeldoc-translate-separator");
-  ztoolkit.Menu.unregister("zotero-menuview-babeldoc-translate-menuitem");
-  ztoolkit.Menu.register("menuView", {
-    id: "zotero-menuview-babeldoc-translate-separator",
-    tag: "menuseparator",
+export function registerWindowMenu(doc: Document) {
+  removeMenuElement(doc, MENU_IDS.viewSeparator);
+  removeMenuElement(doc, MENU_IDS.viewTasks);
+
+  const viewMenu = doc.getElementById("menu_viewPopup");
+  if (!viewMenu) {
+    return;
+  }
+
+  const ui = new UITool();
+  const separator = ui.createElement(doc, "menuseparator", {
+    id: MENU_IDS.viewSeparator,
   });
   // menu->File menuitem
-  ztoolkit.Menu.register("menuView", {
-    id: "zotero-menuview-babeldoc-translate-menuitem",
-    tag: "menuitem",
-    label: getString("menuView-tasks"),
-    commandListener: () => addon.hooks.onViewTranslationTasks(),
+  const menuItem = ui.createElement(doc, "menuitem", {
+    id: MENU_IDS.viewTasks,
+    attributes: {
+      label: getString("menuView-tasks"),
+    },
+    listeners: [
+      {
+        type: "command",
+        listener: () => addon.hooks.onViewTranslationTasks(),
+      },
+    ],
   });
+  viewMenu.append(separator, menuItem);
 }

--- a/src/modules/preference-window.ts
+++ b/src/modules/preference-window.ts
@@ -14,6 +14,20 @@ import {
 } from "../config";
 import type { Language } from "./language/types";
 import { checkIsCN } from "../utils/cn";
+import {
+  DEFAULT_SHORTCUTS,
+  formatShortcutForDisplay,
+  getShortcutFromKeyboardEvent,
+  isBareShiftLetterShortcut,
+  normalizeShortcutString,
+} from "./shortcuts";
+
+type ShortcutInputConfig = {
+  inputId: string;
+  resetId: string;
+  prefKey: "shortcutTranslate" | "shortcutTaskManager";
+  otherPrefKey: "shortcutTranslate" | "shortcutTaskManager";
+};
 
 export function registerPrefs() {
   Zotero.PreferencePanes.register({
@@ -315,6 +329,8 @@ function buildPrefsPane() {
 }
 
 function bindPrefEvents() {
+  bindShortcutPrefEvents();
+
   addon.data
     .prefs!.window.document?.querySelector(
       `#zotero-prefpane-${config.addonRef}-authkey`,
@@ -351,4 +367,98 @@ function bindPrefEvents() {
         });
       }
     });
+}
+
+function bindShortcutPrefEvents() {
+  const doc = addon.data.prefs!.window.document;
+  const shortcutInputs: ShortcutInputConfig[] = [
+    {
+      inputId: `zotero-prefpane-${config.addonRef}-shortcut-translate`,
+      resetId: `zotero-prefpane-${config.addonRef}-shortcut-translate-reset`,
+      prefKey: "shortcutTranslate",
+      otherPrefKey: "shortcutTaskManager",
+    },
+    {
+      inputId: `zotero-prefpane-${config.addonRef}-shortcut-task-manager`,
+      resetId: `zotero-prefpane-${config.addonRef}-shortcut-task-manager-reset`,
+      prefKey: "shortcutTaskManager",
+      otherPrefKey: "shortcutTranslate",
+    },
+  ];
+
+  shortcutInputs.forEach((shortcutInput) => {
+    const input = doc.querySelector<HTMLInputElement>(
+      `#${shortcutInput.inputId}`,
+    );
+    const resetButton = doc.querySelector(`#${shortcutInput.resetId}`);
+    if (!input || !resetButton) {
+      return;
+    }
+
+    input.value = formatShortcutForDisplay(getPref(shortcutInput.prefKey));
+    input.placeholder = formatShortcutForDisplay(
+      DEFAULT_SHORTCUTS[shortcutInput.prefKey],
+    );
+
+    input.addEventListener("keydown", (event) => {
+      const keyboardEvent = event as KeyboardEvent;
+      if (keyboardEvent.key === "Backspace" || keyboardEvent.key === "Delete") {
+        return;
+      }
+      keyboardEvent.preventDefault();
+      const shortcutValue = normalizeShortcutFromInputEvent(keyboardEvent);
+      if (shortcutValue) {
+        input.value = shortcutValue;
+        saveShortcutPref(shortcutInput, input);
+      }
+    });
+    input.addEventListener("change", () =>
+      saveShortcutPref(shortcutInput, input),
+    );
+    input.addEventListener("input", () =>
+      saveShortcutPref(shortcutInput, input),
+    );
+    resetButton.addEventListener("command", () => {
+      input.value = formatShortcutForDisplay(
+        DEFAULT_SHORTCUTS[shortcutInput.prefKey],
+      );
+      saveShortcutPref(shortcutInput, input);
+    });
+  });
+}
+
+function normalizeShortcutFromInputEvent(event: KeyboardEvent): string {
+  return getShortcutFromKeyboardEvent(event);
+}
+
+function saveShortcutPref(
+  shortcutInput: ShortcutInputConfig,
+  input: HTMLInputElement,
+) {
+  const normalizedValue = normalizeShortcutString(input.value);
+  const otherValue = normalizeShortcutString(
+    getPref(shortcutInput.otherPrefKey),
+  );
+  if (normalizedValue !== "" && normalizedValue === otherValue) {
+    input.value = formatShortcutForDisplay(getPref(shortcutInput.prefKey));
+    setShortcutFeedback(getString("pref-shortcut-duplicate-error"));
+    return;
+  }
+  if (isBareShiftLetterShortcut(normalizedValue)) {
+    input.value = formatShortcutForDisplay(getPref(shortcutInput.prefKey));
+    setShortcutFeedback(getString("pref-shortcut-native-conflict-error"));
+    return;
+  }
+  input.value = formatShortcutForDisplay(normalizedValue);
+  setPref(shortcutInput.prefKey, normalizedValue);
+  setShortcutFeedback(getString("pref-shortcut-conflict-guidance"));
+}
+
+function setShortcutFeedback(message: string) {
+  const feedback = addon.data.prefs!.window.document.querySelector(
+    `#zotero-prefpane-${config.addonRef}-shortcut-feedback`,
+  );
+  if (feedback) {
+    feedback.textContent = message;
+  }
 }

--- a/src/modules/shortcuts.ts
+++ b/src/modules/shortcuts.ts
@@ -1,18 +1,196 @@
+import { getPref } from "../utils/prefs";
+
+type ShortcutAction = "translate" | "showTaskManager";
+type ShortcutPrefKey = "shortcutTranslate" | "shortcutTaskManager";
+type PluginShortcutBinding = {
+  action: ShortcutAction;
+  shortcut: string;
+};
+
+export const DEFAULT_SHORTCUTS: Record<ShortcutPrefKey, string> = {
+  shortcutTranslate: "Mod+Shift+B",
+  shortcutTaskManager: "Mod+Shift+H",
+};
+
+const ACTION_SHORTCUT_PREFS: Record<ShortcutAction, ShortcutPrefKey> = {
+  translate: "shortcutTranslate",
+  showTaskManager: "shortcutTaskManager",
+};
+
 export function registerShortcuts() {
   ztoolkit.Keyboard.register((ev, data) => {
     if (data.type !== "keydown" || ev.repeat) {
       return;
     }
 
-    const key = ev.key.toUpperCase();
-    if (ev.shiftKey && key === "A") {
-      const ids = Zotero.getActiveZoteroPane()
-        .getSelectedItems()
-        .map((item) => item.id);
-      addon.hooks.onShortcuts("translate", ids);
+    if (!getPref("enableShortcuts")) {
+      return;
     }
-    if (ev.shiftKey && key === "T") {
-      addon.hooks.onShortcuts("showTaskManager");
+
+    if (isEditableTarget(ev.target)) {
+      return;
+    }
+
+    if (isBareShiftLetter(ev)) {
+      return;
+    }
+
+    const pressedShortcut = getShortcutFromKeyboardEvent(ev);
+    if (!pressedShortcut) {
+      return;
+    }
+
+    const action = getPluginShortcutAction(pressedShortcut);
+    if (!action) {
+      return;
+    }
+    addon.hooks.onShortcuts(action);
+  });
+}
+
+function isBareShiftLetter(ev: KeyboardEvent): boolean {
+  return (
+    ev.shiftKey &&
+    !ev.ctrlKey &&
+    !ev.metaKey &&
+    !ev.altKey &&
+    ev.key.length === 1 &&
+    /^[a-z]$/i.test(ev.key)
+  );
+}
+
+export function isBareShiftLetterShortcut(shortcut: string): boolean {
+  return /^Shift\+[A-Z]$/.test(normalizeShortcutString(shortcut));
+}
+
+export function normalizeShortcutString(value: string): string {
+  const parts = value
+    .split("+")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const modifiers = new Set<string>();
+  const keys: string[] = [];
+
+  parts.forEach((part) => {
+    const lowerPart = part.toLowerCase();
+    // `Mod` is the cross-platform primary modifier (Cmd on macOS,
+    // Ctrl elsewhere). Keep the explicit `Control` token separate so users can
+    // still bind physical Ctrl on macOS or physical Meta on Windows/Linux.
+    if (["mod", "cmd", "command", "meta", "⌘"].includes(lowerPart)) {
+      modifiers.add("Mod");
+    } else if (["ctrl", "⌃"].includes(lowerPart)) {
+      modifiers.add("Mod");
+    } else if (lowerPart === "control") {
+      modifiers.add("Control");
+    } else if (lowerPart === "shift" || lowerPart === "⇧") {
+      modifiers.add("Shift");
+    } else if (["alt", "option", "opt", "⌥"].includes(lowerPart)) {
+      modifiers.add("Alt");
+    } else {
+      keys.push(normalizeKey(part));
     }
   });
+
+  if (keys.length === 0) {
+    return "";
+  }
+
+  return [...sortModifiers(modifiers), keys[keys.length - 1]].join("+");
+}
+
+export function formatShortcutForDisplay(shortcut: string): string {
+  const normalized = normalizeShortcutString(shortcut);
+  if (!normalized) {
+    return "";
+  }
+  return normalized.replace("Mod", isMacOS() ? "Cmd" : "Ctrl");
+}
+
+function getPluginShortcutAction(
+  pressedShortcut: string,
+): ShortcutAction | null {
+  const binding = getConfiguredPluginShortcutWhitelist().find(
+    ({ shortcut }) => shortcut === pressedShortcut,
+  );
+  return binding?.action ?? null;
+}
+
+function getConfiguredPluginShortcutWhitelist(): PluginShortcutBinding[] {
+  return (
+    Object.entries(ACTION_SHORTCUT_PREFS) as [ShortcutAction, ShortcutPrefKey][]
+  )
+    .map(([action, prefKey]) => ({
+      action,
+      shortcut: normalizeShortcutString(getPref(prefKey)),
+    }))
+    .filter(({ shortcut }) => shortcut !== "");
+}
+
+export function getShortcutFromKeyboardEvent(ev: KeyboardEvent): string {
+  const modifiers = new Set<string>();
+  const macOS = isMacOS();
+  if ((macOS && ev.metaKey) || (!macOS && ev.ctrlKey)) {
+    modifiers.add("Mod");
+  }
+  if ((macOS && ev.ctrlKey) || (!macOS && ev.metaKey)) {
+    modifiers.add("Control");
+  }
+  if (ev.altKey) {
+    modifiers.add("Alt");
+  }
+  if (ev.shiftKey) {
+    modifiers.add("Shift");
+  }
+
+  const key = normalizeKey(ev.key);
+  if (!key || ["Control", "Shift", "Alt", "Meta"].includes(key)) {
+    return "";
+  }
+  return [...sortModifiers(modifiers), key].join("+");
+}
+
+function normalizeKey(key: string): string {
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+
+  const keyMap: Record<string, string> = {
+    " ": "Space",
+    esc: "Escape",
+    return: "Enter",
+    arrowup: "ArrowUp",
+    arrowdown: "ArrowDown",
+    arrowleft: "ArrowLeft",
+    arrowright: "ArrowRight",
+  };
+  const lowerKey = key.toLowerCase();
+  return keyMap[lowerKey] || key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+function sortModifiers(modifiers: Set<string>): string[] {
+  const order = ["Mod", "Control", "Alt", "Shift"];
+  return order.filter((modifier) => modifiers.has(modifier));
+}
+
+function isMacOS(): boolean {
+  if (typeof Zotero !== "undefined" && (Zotero as any).isMac !== undefined) {
+    return Boolean((Zotero as any).isMac);
+  }
+  const platform = (Zotero as any).getMainWindow?.().navigator?.platform || "";
+  return /Mac/i.test(platform);
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  const element = target as Element | null;
+  if (!element?.tagName) {
+    return false;
+  }
+  const tagName = element.tagName.toLowerCase();
+  return (
+    tagName === "input" ||
+    tagName === "textarea" ||
+    tagName === "select" ||
+    element.getAttribute("contenteditable") === "true" ||
+    (element as HTMLElement).isContentEditable
+  );
 }

--- a/src/modules/shortcuts.ts
+++ b/src/modules/shortcuts.ts
@@ -1,9 +1,17 @@
 export function registerShortcuts() {
   ztoolkit.Keyboard.register((ev, data) => {
-    if (ev.shiftKey && ev.key === "A") {
-      addon.hooks.onShortcuts("translate");
+    if (data.type !== "keydown" || ev.repeat) {
+      return;
     }
-    if (ev.shiftKey && ev.key === "T") {
+
+    const key = ev.key.toUpperCase();
+    if (ev.shiftKey && key === "A") {
+      const ids = Zotero.getActiveZoteroPane()
+        .getSelectedItems()
+        .map((item) => item.id);
+      addon.hooks.onShortcuts("translate", ids);
+    }
+    if (ev.shiftKey && key === "T") {
       addon.hooks.onShortcuts("showTaskManager");
     }
   });

--- a/src/modules/translate/confirm-dialog.ts
+++ b/src/modules/translate/confirm-dialog.ts
@@ -9,7 +9,15 @@ import { getLanguageOptions } from "../language";
 import { checkIsCN } from "../../utils/cn";
 import type { Language } from "../language/types";
 
-export async function showConfirmationDialog(): Promise<{
+export type ConfirmationArticleInfo = {
+  count: number;
+  title?: string;
+  metadata?: string;
+};
+
+export async function showConfirmationDialog(
+  articleInfo?: ConfirmationArticleInfo,
+): Promise<{
   action: "confirm" | "cancel";
   data?: {
     targetLanguage: Language;
@@ -25,7 +33,18 @@ export async function showConfirmationDialog(): Promise<{
   const isCN = checkIsCN();
   const real_translateModels = isCN ? translateModels_CN : translateModels;
 
-  const dialogHelper = new ztoolkit.Dialog(11, 4)
+  const articleTitle =
+    articleInfo?.title || getString("confirm-article-unknown");
+  const articleMetadata =
+    articleInfo?.metadata || getString("confirm-article-metadata-unknown");
+  const articleSummary =
+    articleInfo && articleInfo.count > 1
+      ? getString("confirm-article-multiple", {
+          args: { count: articleInfo.count },
+        })
+      : getString("confirm-article-single");
+
+  const dialogHelper = new ztoolkit.Dialog(12, 4)
     .addCell(0, 0, {
       tag: "h2",
       properties: {
@@ -36,6 +55,64 @@ export async function showConfirmationDialog(): Promise<{
       },
     })
     .addCell(1, 0, {
+      tag: "div",
+      namespace: "html",
+      styles: {
+        width: "360px",
+        maxWidth: "360px",
+        border: "1px solid var(--fill-quinary)",
+        borderRadius: "6px",
+        padding: "8px",
+        margin: "4px 0 10px 0",
+      },
+      children: [
+        {
+          tag: "div",
+          namespace: "html",
+          properties: {
+            innerText: articleSummary,
+          },
+          styles: {
+            fontSize: "12px",
+            color: "var(--fill-secondary)",
+            marginBottom: "4px",
+          },
+        },
+        {
+          tag: "div",
+          namespace: "html",
+          attributes: {
+            title: articleTitle,
+          },
+          properties: {
+            innerText: articleTitle,
+          },
+          styles: {
+            maxWidth: "340px",
+            maxHeight: "2.8em",
+            overflow: "hidden",
+            lineHeight: "1.4",
+            fontWeight: "600",
+          },
+        },
+        {
+          tag: "div",
+          namespace: "html",
+          properties: {
+            innerText: articleMetadata,
+          },
+          styles: {
+            maxWidth: "340px",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            marginTop: "4px",
+            color: "var(--fill-secondary)",
+          },
+        },
+      ],
+    })
+    .addCell(2, 0, {
       tag: "label",
       namespace: "html",
       properties: {
@@ -46,7 +123,7 @@ export async function showConfirmationDialog(): Promise<{
       },
     })
     .addCell(
-      2,
+      3,
       0,
       {
         tag: "select",
@@ -72,7 +149,7 @@ export async function showConfirmationDialog(): Promise<{
       },
       false,
     )
-    .addCell(3, 0, {
+    .addCell(4, 0, {
       tag: "label",
       namespace: "html",
       properties: {
@@ -83,7 +160,7 @@ export async function showConfirmationDialog(): Promise<{
       },
     })
     .addCell(
-      4,
+      5,
       0,
       {
         tag: "select",
@@ -109,7 +186,7 @@ export async function showConfirmationDialog(): Promise<{
       },
       false,
     )
-    .addCell(5, 0, {
+    .addCell(6, 0, {
       tag: "label",
       namespace: "html",
       properties: {
@@ -120,7 +197,7 @@ export async function showConfirmationDialog(): Promise<{
       },
     })
     .addCell(
-      6,
+      7,
       0,
       {
         tag: "select",

--- a/src/modules/translate/task.ts
+++ b/src/modules/translate/task.ts
@@ -24,13 +24,19 @@ export function isAttachmentInTaskList(attachmentId: number): boolean {
   );
 }
 
-export async function addTasksToQueue(ids?: number[]) {
+type ConfirmationArticleInfo = {
+  count: number;
+  title?: string;
+  metadata?: string;
+};
+
+async function validateTranslationAuth(): Promise<boolean> {
   const authkey = getPref("authkey");
   if (!authkey) {
     showDialog({
       title: getString("pref-test-failed-description"),
     });
-    return;
+    return false;
   }
   const result = await addon.api.checkAuthKey({
     apiKey: authkey,
@@ -39,15 +45,29 @@ export async function addTasksToQueue(ids?: number[]) {
     showDialog({
       title: getString("pref-test-failed-description"),
     });
+    return false;
+  }
+
+  return true;
+}
+
+export async function addTasksToQueue() {
+  if (!(await validateTranslationAuth())) {
     return;
   }
 
-  // 根据是否传入 ids 参数选择不同的获取任务方式
-  const tasksToQueue =
-    ids && ids.length > 0
-      ? await getTranslationTasksByIds(ids)
-      : await getTranslationTasks();
+  await addTasksToQueueFromTasks(await getTranslationTasks());
+}
 
+export async function addTasksToQueueByIds(ids: number[]) {
+  if (!(await validateTranslationAuth())) {
+    return;
+  }
+
+  await addTasksToQueueFromTasks(await getTranslationTasksByIds(ids));
+}
+
+async function addTasksToQueueFromTasks(tasksToQueue: TranslationTaskData[]) {
   if (tasksToQueue.length === 0) {
     ztoolkit.log("No valid PDF attachments found to add to the queue.");
     showDialog({
@@ -58,7 +78,9 @@ export async function addTasksToQueue(ids?: number[]) {
   const translateMode = getPref("translateMode");
   const translateModel = getPref("translateModel");
   const targetLanguage = getPref("targetLanguage") as Language;
-  const confirmResult = await showConfirmationDialog();
+  const confirmResult = await showConfirmationDialog(
+    getConfirmationArticleInfo(tasksToQueue),
+  );
   if (confirmResult.action === "cancel") {
     return;
   }
@@ -141,6 +163,36 @@ async function getTranslationTasks(): Promise<TranslationTaskData[]> {
 
   ztoolkit.log("Found tasks (after refined deduplication):", tasks);
   return tasks;
+}
+
+function getConfirmationArticleInfo(
+  tasksToQueue: TranslationTaskData[],
+): ConfirmationArticleInfo {
+  const firstTask = tasksToQueue[0];
+  const uniqueParentIds = new Set(
+    tasksToQueue
+      .map((task) => task.parentItemId || task.attachmentId)
+      .filter((id): id is number => typeof id === "number"),
+  );
+  const parentItem = firstTask?.parentItemId
+    ? Zotero.Items.get(firstTask.parentItemId)
+    : undefined;
+  const title = firstTask?.parentItemTitle || firstTask?.attachmentFilename;
+  const metadataParts = [];
+  if (parentItem?.firstCreator) {
+    metadataParts.push(parentItem.firstCreator);
+  }
+  const date = parentItem?.getField("date", true, true) as string | undefined;
+  const year = date?.substring(0, 4);
+  if (year && year !== "0000") {
+    metadataParts.push(year);
+  }
+
+  return {
+    count: uniqueParentIds.size || tasksToQueue.length,
+    title,
+    metadata: metadataParts.join(" · "),
+  };
 }
 
 // 处理单个条目，提取其中的PDF附件并创建翻译任务

--- a/src/utils/menu.ts
+++ b/src/utils/menu.ts
@@ -1,0 +1,13 @@
+export const MENU_IDS = {
+  itemTranslate: "zotero-itemmenu-babeldoc-translate",
+  viewSeparator: "zotero-menuview-babeldoc-translate-separator",
+  viewTasks: "zotero-menuview-babeldoc-translate-menuitem",
+} as const;
+
+export function removeMenuElement(doc: Document, id: string): void {
+  doc.getElementById(id)?.remove();
+}
+
+export function removeKnownMenuElements(doc: Document): void {
+  Object.values(MENU_IDS).forEach((id) => removeMenuElement(doc, id));
+}

--- a/src/utils/ztoolkit.ts
+++ b/src/utils/ztoolkit.ts
@@ -3,12 +3,8 @@ import { config } from "../../package.json";
 
 export { createZToolkit };
 
-type ZToolkitWithMenu = ZoteroToolkit & {
-  Menu: any;
-};
-
-function createZToolkit(): ZToolkitWithMenu {
-  const _ztoolkit = new ZoteroToolkit() as ZToolkitWithMenu;
+function createZToolkit(): ZoteroToolkit {
+  const _ztoolkit = new ZoteroToolkit();
   /**
    * Alternatively, import toolkit modules you use to minify the plugin size.
    * You can add the modules under the `MyToolkit` class below and uncomment the following line.

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -22,6 +22,8 @@ declare namespace _ZoteroTypes {
       "customSystemPrompt": string;
       "fakeUserId": string;
       "enableShortcuts": boolean;
+      "shortcutTranslate": string;
+      "shortcutTaskManager": string;
       "layoutModel": string;
       "skipNetworkWarning": boolean;
     };

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -1,5 +1,36 @@
 import { defineConfig } from "zotero-plugin-scaffold";
+import { readFileSync } from "node:fs";
 import pkg from "./package.json";
+
+const toolkitImportHelperBefore =
+  'if (typeof ChromeUtils.import === "undefined") return ChromeUtils.importESModule(path, { global: "contextual" });\n\tif (path.endsWith(".sys.mjs")) path = path.replace(/\\.sys\\.mjs$/, ".jsm");\n\treturn ChromeUtils.import(path);';
+
+const toolkitImportHelperAfter =
+  'try {\n\t\treturn ChromeUtils.importESModule(path, { global: "contextual" });\n\t} catch (error) {\n\t\tif (typeof ChromeUtils["import"] === "undefined") throw error;\n\t}\n\tif (path.endsWith(".sys.mjs")) path = path.replace(/\\.sys\\.mjs$/, ".jsm");\n\treturn ChromeUtils["import"](path);';
+
+const toolkitImportCompatPlugin = {
+  name: "toolkit-import-compat",
+  setup(build: any) {
+    build.onLoad(
+      { filter: /zotero-plugin-toolkit\/dist\/index\.js$/ },
+      (args: { path: string }) => {
+        const source = readFileSync(args.path, "utf8");
+        if (!source.includes(toolkitImportHelperBefore)) {
+          throw new Error(
+            "zotero-plugin-toolkit import helper shape changed; update toolkit-import-compat patch before building.",
+          );
+        }
+        return {
+          contents: source.replace(
+            toolkitImportHelperBefore,
+            toolkitImportHelperAfter,
+          ),
+          loader: "js",
+        };
+      },
+    );
+  },
+};
 
 export default defineConfig({
   source: ["src", "addon"],
@@ -38,6 +69,7 @@ export default defineConfig({
           __OLD_GA_API_SECRET__: `"${process.env.OLD_GA_API_SECRET}"`,
         },
         bundle: true,
+        plugins: [toolkitImportCompatPlugin],
         target: "firefox115",
         outfile: `dist/addon/content/scripts/${pkg.config.addonRef}.js`,
       },


### PR DESCRIPTION
## Summary

This PR adds customizable plugin shortcuts and updates the translation confirmation flow.

### Changes

- Replace fixed `Shift+A` / `Shift+T` shortcuts with configurable shortcuts.
- Add default shortcuts:
  - Translate: `Ctrl/Cmd+Shift+B`
  - Task manager: `Ctrl/Cmd+Shift+H`
- Add shortcut settings UI with edit, clear, reset, duplicate detection, and immediate apply.
- Protect Zotero native `Shift+letter` item navigation with runtime guards.
- Use a dynamic shortcut whitelist so non-plugin key events return before plugin dispatch.
- Remove shortcut selected-ID pre-read; shortcut translation now uses the normal selected-item flow.
- Preserve ID-based queueing only for notifier/auto-translate flow.
- Show article title/metadata in the translation confirmation dialog.
- Patch bundled toolkit import helper to prefer `ChromeUtils.importESModule(...)` for Zotero 9 compatibility.
- Restore auth validation before translation task collection.

### Verification

- Checked production changed files with Prettier.
- Checked production changed files with ESLint.
- Built locally under Node 20 with `pnpm build`.
- Verified generated XPI at `dist/immersive-translate.xpi`.